### PR TITLE
support 2-arity import-with-frame for def-like var resolution

### DIFF
--- a/src/re_frame/context.clj
+++ b/src/re_frame/context.clj
@@ -18,8 +18,7 @@
   ([var-sym]
    `(import-with-frame ~(symbol (name var-sym)) ~var-sym))
   ([name var-sym]
-   `(defn
-      ~(symbol (name var-sym))
+   `(defn ~name
       ;; Attempt at propagating the doc string / arglists, for some reason CIDER
       ;; is not picking this up though.
       ~(select-keys (:meta (cljs.analyzer/resolve-var cljs.env/*compiler* var-sym))

--- a/src/re_frame/context.clj
+++ b/src/re_frame/context.clj
@@ -14,12 +14,15 @@
        ^{:context-type frame-context}
        (fn ~@fntail))))
 
-(defmacro import-with-frame [var-sym]
-  `(defn
-     ~(symbol (name var-sym))
-     ;; Attempt at propagating the doc string / arglists, for some reason CIDER
-     ;; is not picking this up though.
-     ~(select-keys (:meta (cljs.analyzer/resolve-var cljs.env/*compiler* var-sym))
-                   [:doc :arglists])
-     [& args#]
-     (apply ~var-sym (current-frame) args#)))
+(defmacro import-with-frame
+  ([var-sym]
+   `(import-with-frame ~(symbol (name var-sym)) ~var-sym))
+  ([name var-sym]
+   `(defn
+      ~(symbol (name var-sym))
+      ;; Attempt at propagating the doc string / arglists, for some reason CIDER
+      ;; is not picking this up though.
+      ~(select-keys (:meta (cljs.analyzer/resolve-var cljs.env/*compiler* var-sym))
+                    [:doc :arglists])
+      [& args#]
+      (apply ~var-sym (current-frame) args#))))

--- a/src/re_frame/context.cljs
+++ b/src/re_frame/context.cljs
@@ -54,18 +54,18 @@
 ;; approach then import re-frame.context instead of re-frame.core and things
 ;; should generally Just Work™
 
-(import-with-frame re-frame.frame/subscribe)
-(import-with-frame re-frame.frame/dispatch)
-(import-with-frame re-frame.frame/dispatch-sync)
-(import-with-frame re-frame.frame/clear-sub)
-(import-with-frame re-frame.frame/reg-fx)
-(import-with-frame re-frame.frame/reg-cofx)
-(import-with-frame re-frame.frame/inject-cofx)
-(import-with-frame re-frame.frame/clear-cofx)
-(import-with-frame re-frame.frame/reg-event-db)
-(import-with-frame re-frame.frame/reg-event-fx)
-(import-with-frame re-frame.frame/reg-event-ctx)
-(import-with-frame re-frame.frame/clear-event)
+(import-with-frame subscribe re-frame.frame/subscribe)
+(import-with-frame dispatch re-frame.frame/dispatch)
+(import-with-frame dispatch-sync re-frame.frame/dispatch-sync)
+(import-with-frame clear-sub re-frame.frame/clear-sub)
+(import-with-frame reg-fx re-frame.frame/reg-fx)
+(import-with-frame reg-cofx re-frame.frame/reg-cofx)
+(import-with-frame inject-cofx re-frame.frame/inject-cofx)
+(import-with-frame clear-cofx re-frame.frame/clear-cofx)
+(import-with-frame reg-event-db re-frame.frame/reg-event-db)
+(import-with-frame reg-event-fx re-frame.frame/reg-event-fx)
+(import-with-frame reg-event-ctx re-frame.frame/reg-event-ctx)
+(import-with-frame clear-event re-frame.frame/clear-event)
 
 ;; A few special cases which we can't import directly
 


### PR DESCRIPTION
I've been wanting to do something so that Cursive can resolve the functions in `re-frame.context`, open to feedback on the approach.

I tried following the format of `potemkin/import-vars`, which cursive is _supposed_ to resolve, but it did not work, so I resorted to this `def`-like behaviour.