### PR TITLE
Revert "Add more logging"

### DIFF
--- a/src/re_frame/events.cljc
+++ b/src/re_frame/events.cljc
@@ -1,10 +1,10 @@
 (ns re-frame.events
-  (:require [re-frame.utils :refer [first-in-vector]]
-            [re-frame.interop :refer [empty-queue debug-enabled?]]
-            [re-frame.registry :as reg]
-            [re-frame.loggers :refer [console]]
-            [re-frame.interceptor :as interceptor]
-            [re-frame.trace :as trace :include-macros true]))
+  (:require [re-frame.utils       :refer [first-in-vector]]
+            [re-frame.interop     :refer [empty-queue debug-enabled?]]
+            [re-frame.registry    :as reg]
+            [re-frame.loggers     :refer [console]]
+            [re-frame.interceptor :as  interceptor]
+            [re-frame.trace       :as trace :include-macros true]))
 
 
 (def kind :event)

--- a/src/re_frame/router.cljc
+++ b/src/re_frame/router.cljc
@@ -2,8 +2,7 @@
   (:require [re-frame.events :as ev]
             [re-frame.interop :refer [after-render empty-queue next-tick]]
             [re-frame.loggers :refer [console]]
-            [re-frame.trace :as trace :include-macros true]
-            [lambdaisland.glogi :as log]))
+            [re-frame.trace :as trace :include-macros true]))
 
 
 ;; -- Router Loop ------------------------------------------------------------
@@ -245,10 +244,9 @@
      (dispatch event-queue [:order-pizza {:supreme 2 :meatlovers 1 :veg 1})"
   [event-queue event]
   {:pre [event-queue]}
-  (log/trace :dispatch event :frame-id (:frame-id (.-frame event-queue)))
   (if (nil? event)
-    (throw (ex-info "re-frame: you called \"dispatch\" without an event vector." {}))
-    (push event-queue event))
+      (throw (ex-info "re-frame: you called \"dispatch\" without an event vector." {}))
+      (push event-queue event))
   nil)                                           ;; Ensure nil return. See https://github.com/day8/re-frame/wiki/Beware-Returning-False
 
 
@@ -266,8 +264,6 @@
   Usage:
      (dispatch-sync event-queue registry [:sing :falsetto 634])"
   [frame event-v]
-  (log/trace :dispatch-sync event-v :frame-id (:frame-id frame))
-
   (ev/handle frame event-v)
 
   ;; slightly ugly hack. Run the registered post event callbacks.

--- a/src/re_frame/subs.cljc
+++ b/src/re_frame/subs.cljc
@@ -123,8 +123,7 @@
 
   XXX
   "
-  ([{:keys [registry app-db subs-cache frame-id] :as frame} query]
-   (log/trace :subscribe query :frame-id frame-id)
+  ([{:keys [registry app-db subs-cache] :as frame} query]
    (trace/with-trace {:operation (first-in-vector query)
                       :op-type   :sub/create
                       :tags      {:query-v query}}
@@ -143,7 +142,6 @@
            (-cache-and-return subs-cache query [] (handler-fn frame query)))))))
 
   ([{:keys [registry app-db subs-cache] :as frame} query dynv]
-   (log/trace :subscribe {:query query :dynv dynv})
    (trace/with-trace {:operation (first-in-vector query)
                       :op-type   :sub/create
                       :tags      {:query-v query
@@ -392,7 +390,6 @@
                                                   :tags      {:query-v    query-vec
                                                               :reaction   @reaction-id}}
                                  (let [subscription (computation-fn (deref-input-signals subscriptions query-id) query-vec)]
-                                   (log/fine :updated {:query query-vec :result subscription})
                                    (trace/merge-trace! {:tags {:value subscription}})
                                    subscription))))]
 
@@ -410,7 +407,6 @@
                                                               :dyn-v     dyn-vec
                                                               :reaction  @reaction-id}}
                                  (let [subscription (computation-fn (deref-input-signals subscriptions query-id) query-vec dyn-vec)]
-                                   (log/fine :updated {:query query-vec :dyn-vec dyn-vec :result subscription})
                                    (trace/merge-trace! {:tags {:value subscription}})
                                    subscription))))]
 


### PR DESCRIPTION
This reverts commit 3a18584755e784b95b2be5878e26f61270eeb2e6.

Seems to prevent us from updating freerange in https://github.com/nextjournal/nextjournal/pull/5377 (commit https://github.com/nextjournal/nextjournal/pull/5377/commits/d13bb4f363005595e1a26d7fe6252ee4b6b4f881)

Not saying this has to be merged but will try updating to this ref in https://github.com/nextjournal/nextjournal/pull/5377.