### PR TITLE
Ensure a defaut logger is set before using glogi

### DIFF
--- a/src/re_frame/core.cljc
+++ b/src/re_frame/core.cljc
@@ -1,5 +1,6 @@
 (ns re-frame.core
-  (:require [re-frame.events :as events]
+  (:require [lambdaisland.glogi :as glogi]
+            [re-frame.events :as events]
             [re-frame.subs :as subs]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
@@ -10,6 +11,11 @@
             [re-frame.registry :as reg]
             [re-frame.interceptor :as interceptor]
             [re-frame.std-interceptors :as std-interceptors]))
+
+#?(:cljs
+   (glogi/set-levels
+    {:glogi/root :info}))
+
 
 ;; -- API ---------------------------------------------------------------------
 ;;


### PR DESCRIPTION
This should prevent `Failure: Root logger has no level set.` errors when logs are produced, e.g. while registering default handlers when loading the namespace.

This assumes a consumer of freerange then sets their own default log level anyway if they also use glogi, so my understanding is this shouldn't impact consumers.